### PR TITLE
Using Ref to avoid copies when calling solve

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,12 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: Cleanup windows environment
+      shell: bash
+      run: |
+        set -x
+        rm -rf /c/hostedtoolcache/windows/Boost/1.72.0/lib/cmake/Boost-1.72.0
+      if: matrix.os == 'windows-latest'
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
       with:

--- a/src/QuadProg.cpp
+++ b/src/QuadProg.cpp
@@ -76,8 +76,8 @@ void QuadProgCommon::problem(int nrvar, int nreq, int nrineq)
 
 
 void QuadProgCommon::fillQCBf(int nreq, int nrineq,
-	const MatrixXd& Q, const VectorXd& C,
-	const VectorXd& Beq, const VectorXd& Bineq,
+	const Ref<const MatrixXd>& Q, const Ref<const VectorXd>& C,
+	const Ref<const VectorXd>& Beq, const Ref<const VectorXd>& Bineq,
 	bool isDecomp)
 {
 	Q_ = Q;
@@ -116,9 +116,9 @@ void QuadProgDense::problem(int nrvar, int nreq, int nrineq)
 }
 
 
-bool QuadProgDense::solve(const MatrixXd& Q, const VectorXd& C,
-	const MatrixXd& Aeq, const VectorXd& Beq,
-	const MatrixXd& Aineq, const VectorXd& Bineq,
+bool QuadProgDense::solve(const Ref<const MatrixXd>& Q, const Ref<const VectorXd>& C,
+	const Ref<const MatrixXd>& Aeq, const Ref<const VectorXd>& Beq,
+	const Ref<const MatrixXd>& Aineq, const Ref<const VectorXd>& Bineq,
 	bool isDecomp)
 {
 	int nrvar = static_cast<int>(C.rows());
@@ -181,9 +181,9 @@ void QuadProgSparse::problem(int nrvar, int nreq, int nrineq)
 }
 
 
-bool QuadProgSparse::solve(const MatrixXd& Q, const VectorXd& C,
-	const SparseMatrix<double>& Aeq, const VectorXd& Beq,
-	const SparseMatrix<double>& Aineq, const VectorXd& Bineq,
+bool QuadProgSparse::solve(const Ref<const MatrixXd>& Q, const Ref<const VectorXd>& C,
+	const SparseMatrix<double>& Aeq, const Ref<const VectorXd>& Beq,
+	const SparseMatrix<double>& Aineq, const Ref<const VectorXd>& Bineq,
 	bool isDecomp)
 {
 	int nrvar = static_cast<int>(C.rows());

--- a/src/QuadProg.h
+++ b/src/QuadProg.h
@@ -87,8 +87,8 @@ public:
 
 protected:
 	void fillQCBf(int nreq, int nrineq,
-		const MatrixXd& Q, const VectorXd& C,
-		const VectorXd& Beq, const VectorXd& Bineq,
+		const Ref<const MatrixXd>& Q, const Ref<const VectorXd>& C,
+		const Ref<const VectorXd>& Beq, const Ref<const VectorXd>& Bineq,
 		bool isDecomp);
 
 protected:
@@ -155,9 +155,9 @@ public:
      * \return success True if the solver found a solution.
      *
      */
-	EIGEN_QUADPROG_API bool solve(const MatrixXd& Q, const VectorXd& C,
-		const MatrixXd& Aeq, const VectorXd& Beq,
-		const MatrixXd& Aineq, const VectorXd& Bineq,
+	EIGEN_QUADPROG_API bool solve(const Ref<const MatrixXd>& Q, const Ref<const VectorXd>& C,
+		const Ref<const MatrixXd>& Aeq, const Ref<const VectorXd>& Beq,
+		const Ref<const MatrixXd>& Aineq, const Ref<const VectorXd>& Bineq,
 		bool isDecomp=false);
 
 private:
@@ -230,9 +230,9 @@ public:
      * \return success True if the solver found a solution.
      *
      */
-	EIGEN_QUADPROG_API bool solve(const MatrixXd& Q, const VectorXd& C,
-		const SparseMatrix<double>& Aeq, const VectorXd& Beq,
-		const SparseMatrix<double>& Aineq, const VectorXd& Bineq,
+	EIGEN_QUADPROG_API bool solve(const Ref<const MatrixXd>& Q, const Ref<const VectorXd>& C,
+		const SparseMatrix<double>& Aeq, const Ref<const VectorXd>& Beq,
+		const SparseMatrix<double>& Aineq, const Ref<const VectorXd>& Bineq,
 		bool isDecomp=false);
 
 private:


### PR DESCRIPTION
This PR makes the signature of solve more flexible with the use of Ref.


As a side note, the indentation of both .h and .cpp files is a happy mix of tab and space. Shall I add a clang-format to the PR?